### PR TITLE
omni1000: Change mmcdev for mmc 1

### DIFF
--- a/include/configs/omni1000.h
+++ b/include/configs/omni1000.h
@@ -121,7 +121,7 @@
 
 #if defined(CONFIG_ENV_IS_IN_MMC)
 /* Environment in eMMC, before config block at the end of 1st "boot sector" */
-#define CONFIG_SYS_MMC_ENV_DEV		0
+#define CONFIG_SYS_MMC_ENV_DEV		1
 #define CONFIG_SYS_MMC_ENV_PART		1
 #endif
 


### PR DESCRIPTION
The mmc of the apalis module is mapped as mmc 1. To boot the system from
it, the device needs to be set to 1.

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>